### PR TITLE
CR-851 Fixed compile error. Re-instated local variable

### DIFF
--- a/locust_tasks/locustfile.py
+++ b/locust_tasks/locustfile.py
@@ -145,7 +145,7 @@ class LaunchEQwithAddressCorrection(TaskSequence):
 
     @seq_task(4)
     def correct_address(self):
-        self.client.post("/en/start/address-edit", {
+        response = self.client.post("/en/start/address-edit", {
             'address-line-1': '1 High Street',
             'address-line-2': 'Smithfields',
             'address-line-3': '',


### PR DESCRIPTION
Fix compile error by re-instating a local variable. This should not have been removed.
Didn't discover because that test sequence is not being used.