### PR TITLE
Cr 922 locust uac paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ It's also a good way of quickly testing changes to locustfile.py.
 
 To avoid misleading statistics it's worth doing a '--reset-stats', so that the stats are cleared down when all clients have been hatched.
 
+To **debug** errors look at the detailed failure information in the locust-worker logs. If the failure is reproducible
+then it's usually easiest to run a local locust against the failing RH in census-rh-performance. 
+
 ### Real world Locust comments
 
 Locust is not a performance measurement tool so it's best to only use its timings for guidance. If you want

--- a/README.md
+++ b/README.md
@@ -44,22 +44,25 @@ Before issuing an Kubertetes commands the following substitutions will be needed
 * TARGET\_HOST - This is the IP of the RH start page. It can be found in the browser by looking at the 'census-rh-performance' environment. Then 'Services & Ingress' -> ingress -> Load balancer IP. eg, 'http://http://34.107.206.101'
 * RABBITMQ\_CONNECTION - This is used if you want Locust to populate RH Firestore with test data, otherwise use 'nil'.
 
-To build and publish the docker image CATD recommended:
+To build and publish the docker image CATD recommended (where TAG\_NAME is set to something like "CR-123_V1"):
 
     $ export PROJECT_ID="census-rh-loadgen"
-    $ gcp rh loadgen
+    $ export TAG_NAME=<TBD>
     $ docker build -t eu.gcr.io/${PROJECT_ID}/locust-tasks .
-    $ docker push eu.gcr.io/${PROJECT_ID}/locust-tasks:latest
+    $ docker tag eu.gcr.io/${PROJECT_ID}/locust-tasks eu.gcr.io/${PROJECT_ID}/locust-tasks:${TAG_NAME}
+    $ docker push eu.gcr.io/${PROJECT_ID}/locust-tasks:${TAG_NAME}
 
 To deploy:
 
     $ gcloud builds submit --tag gcr.io/[PROJECT_ID]/locust-tasks:latest
+    $ gcp rh loadgen
     $ kubectl apply -f kubernetes_config/master-deployment.yaml
     $ kubectl apply -f kubernetes_config/master-service.yaml
     $ kubectl apply -f kubernetes_config/worker-deployment.yaml
 
 Remove service, deployment.
 
+    $ gcp rh loadgen
     $ kubectl delete svc locust-master
     $ kubectl delete deployment locust-master
     $ kubectl delete deployment locust-worker

--- a/README.md
+++ b/README.md
@@ -16,16 +16,17 @@ Clone the repository. Change to the census-rh-performance-test directory where t
 
 ### Build Docker image and run locally 
 
-To build and publish the docker image CATD recommended:
+To build a new docker image:
 
-    $ export PROJECT_ID="census-rh-loadgen"
-    $ gcp rh loadgen
-    $ docker build -t eu.gcr.io/${PROJECT_ID}/locust-tasks .
-    $ docker push eu.gcr.io/${PROJECT_ID}/locust-tasks:latest
+    $ docker build --tag loadtest:latest .
     
 To run docker locally:
 
-    $ docker run -d -p 5557:5557 -p 5558:5558 -p 8089:8089 -e TARGET_HOST=http://host.docker.internal:9092 -e RABBITMQ_URL=amqp://guest:guest@host.docker.internal:6672 -e DATA_PUBLISH=true loadtest
+    $ docker run -d -p 5557:5557 -p 5558:5558 -p 8089:8089 -e TARGET_HOST=http://host.docker.internal:9092 -e DATA_PUBLISH=false -e INSTANCE_NUM=1 -e MAX_INSTANCES=1 loadtest
+
+If you want the test code to publish the test data to RH on startup then you'll need to set the RABBITMQ\_URL and DATA\_PUBLISH environment variables: 
+ 
+    $ docker run -d -p 5557:5557 -p 5558:5558 -p 8089:8089 -e TARGET_HOST=http://host.docker.internal:9092 -e RABBITMQ_URL=amqp://guest:guest@host.docker.internal:6672 -e DATA_PUBLISH=true -e INSTANCE_NUM=1 -e MAX_INSTANCES=1 loadtest
 
 This and above Run - Local assumes you have RH UI running on port 9092 with all it's dependencies available:
 * RH Service
@@ -42,6 +43,13 @@ Before issuing an Kubertetes commands the following substitutions will be needed
 * PROJECT\_ID - At the time of writing this is 'census-rh-loadgen' for the performance environment.
 * TARGET\_HOST - This is the IP of the RH start page. It can be found in the browser by looking at the 'census-rh-performance' environment. Then 'Services & Ingress' -> ingress -> Load balancer IP. eg, 'http://http://34.107.206.101'
 * RABBITMQ\_CONNECTION - This is used if you want Locust to populate RH Firestore with test data, otherwise use 'nil'.
+
+To build and publish the docker image CATD recommended:
+
+    $ export PROJECT_ID="census-rh-loadgen"
+    $ gcp rh loadgen
+    $ docker build -t eu.gcr.io/${PROJECT_ID}/locust-tasks .
+    $ docker push eu.gcr.io/${PROJECT_ID}/locust-tasks:latest
 
 To deploy:
 

--- a/README.md
+++ b/README.md
@@ -177,4 +177,7 @@ There are a number of environment variable configuration items which can be set:
 * UAC\_ROUTING\_KEY default 'event.uac.update'
 * CASE\_ROUTING\_KEY default 'event.case.update'
 * DATA\_PUBLISH default false, whether to publish test data to Firestore
-
+* INSTANCE\_NUM no default. Is the instance number for the current run. The Locust test will read
+its own section of the event data file. For example if the event data file has 100 cases and this is 
+instance 3 of 4 then it will only read cases 51 to 75 and sequentially use these during testing.
+* MAX\_INSTANCES no default. This is the number of workers that will be sharing the event data file. 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ To build and publish the docker image CATD recommended (where TAG\_NAME is set t
 
 To deploy:
 
-    $ gcloud builds submit --tag gcr.io/[PROJECT_ID]/locust-tasks:latest
     $ gcp rh loadgen
     $ kubectl apply -f kubernetes_config/master-deployment.yaml
     $ kubectl apply -f kubernetes_config/master-service.yaml

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Before issuing an Kubertetes commands the following substitutions will be needed
 * TARGET\_HOST - This is the IP of the RH start page. It can be found in the browser by looking at the 'census-rh-performance' environment. Then 'Services & Ingress' -> ingress -> Load balancer IP. eg, 'http://http://34.107.206.101'
 * RABBITMQ\_CONNECTION - This is used if you want Locust to populate RH Firestore with test data, otherwise use 'nil'.
 
-To build and publish the docker image CATD recommended (where TAG\_NAME is set to something like "CR-123_V1"):
+To make sure that your test run is using the correct version of the Locust tests with your version of the 
+event_data you'll need to build and publish a docker image. To make sure that the correct image is deployed it
+is tagged with a string based on the CR number. ie, TAG\_NAME is set to something like "CR-123_V1".
+
+To build and publish the docker image CATD recommended:
 
     $ export PROJECT_ID="census-rh-loadgen"
     $ export TAG_NAME=<TBD>

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To deploy:
     $ kubectl apply -f kubernetes_config/master-service.yaml
     $ kubectl apply -f kubernetes_config/worker-deployment.yaml
 
-Remove service, deployment.
+To delete Locust deployment:
 
     $ gcp rh loadgen
     $ kubectl delete svc locust-master

--- a/kubernetes/master-deployment.yaml
+++ b/kubernetes/master-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: locust-master

--- a/kubernetes/worker-deployment.yaml
+++ b/kubernetes/worker-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: locust-worker
@@ -34,3 +34,7 @@ spec:
               value: [TARGET_HOST]
             - name: RABBITMQ_URL
               value: [RABBITMQ_CONNECTION]
+            - name: INSTANCE_NUM
+              value: "[INSTANCE_NUM]"
+            - name: MAX_INSTANCES
+              value: "[MAX_INSTANCES]"

--- a/locust_tasks/__init__.py
+++ b/locust_tasks/__init__.py
@@ -6,4 +6,5 @@ EXCHANGE = os.getenv('EXCHANGE') or 'events'
 UAC_ROUTING_KEY = os.getenv('UAC_ROUTING_KEY') or 'event.uac.update'
 CASE_ROUTING_KEY = os.getenv('CASE_ROUTING_KEY') or 'event.case.update'
 DATA_PUBLISH = os.getenv('DATA_PUBLISH') == 'true'
-
+INSTANCE_NUM = os.getenv('INSTANCE_NUM') or None
+MAX_INSTANCES = os.getenv('MAX_INSTANCES') or None

--- a/locust_tasks/locustfile.py
+++ b/locust_tasks/locustfile.py
@@ -285,6 +285,10 @@ def verify_response(id, task, resp, expected_status, expected_page, expected_con
     
     # Content verification
     if expected_content:
+        # Convert expected apostrophes to HTML equivalent
+        if "'" in expected_content:
+            expected_content = expected_content.replace("'", "&#39;")
+        # Check page content
         if expected_content not in resp.text:
             failure_message = f'{current_page.name} page does not contain expected text ({expected_content}).'
             page_extract = extract_key_page_content(id, task, resp, current_page)

--- a/locust_tasks/locustfile.py
+++ b/locust_tasks/locustfile.py
@@ -320,6 +320,7 @@ def report_failure(id, resp, task, failure_message, page_content):
     logger.error(f'ID={id} UAC={task.case["uac"]} Status={resp.status_code}: {failure_message}{error_detail}')
     
     # Slow down error reporting when things are going wrong (otherwise hundreds of errors are logged in just a few seconds)
+    # Note that this sleep does not affect the progress of other tasks
     time.sleep(5.0)
     
     task.interrupt()

--- a/locust_tasks/locustfile.py
+++ b/locust_tasks/locustfile.py
@@ -23,10 +23,6 @@ used in the error message to help debug what has gone wrong.
 If the extract start/end is not specified then the whole page will be added to the error message.
 """ 
 class Page(Enum):
-    ERROR           = ('<title>Error - Census 2021</title>',
-                       'id="main-content"',
-                       '<footer'
-                      )
     START           = ('<title>Start census - Census 2021</title>',
                        'Start Census</h1>',
                        'Enter the 16 character code'
@@ -39,6 +35,19 @@ class Page(Enum):
                        '',
                        ''
                       )
+    ERROR           = ('<title>Error - Census 2021</title>',
+                       'id="main-content"',
+                       '<footer'
+                      )
+    ERROR_502       = ('<title>502 Server Error</title>',
+                       '',
+                       ''
+                      )
+    ERROR_GENERIC   = ('<h1>Error: Server Error</h1>',
+                       '',
+                       ''
+                      )
+
   
     def __init__(self, title, extract_start, extract_end):
         self.title = title

--- a/locust_tasks/setup.py
+++ b/locust_tasks/setup.py
@@ -3,6 +3,7 @@ import csv
 import datetime
 import hashlib
 import sys
+import logging
 
 from uuid import uuid4
 from random import randrange
@@ -12,6 +13,8 @@ from . import FILE_NAME, RABBITMQ_URL, EXCHANGE, UAC_ROUTING_KEY, CASE_ROUTING_K
 case_ref = 84000000
 cases = []
 next_case_index = 0
+
+logger = logging.getLogger('performance')
 
 
 def get_next_case():
@@ -94,7 +97,7 @@ def calculate_section_of_event_data_file(number_records):
     first_record = int(records_per_instance * (instance_num-1))
     last_record = int(records_per_instance * (instance_num)) -1
 
-    sys.stdout.write('Instance %d/%d: Event range: %d...%d inclusive from %d records\n' % (instance_num, max_instances, first_record, last_record, number_records))
+    logger.info('Instance %d/%d: Event range: %d...%d inclusive from %d records\n' % (instance_num, max_instances, first_record, last_record, number_records))
 
     return (first_record, last_record)
     

--- a/locust_tasks/setup.py
+++ b/locust_tasks/setup.py
@@ -28,12 +28,80 @@ def setup():
         publish_test_data()
 
     num_event_rows = get_num_event_data_records()
-    sys.stdout.write('num lines: %d\n' % num_event_rows)
     (first_record, last_record) = calculate_section_of_event_data_file(num_event_rows)            
     read_event_data(first_record, last_record)
 
 
+def get_num_event_data_records():
+    """
+    This function reads the event data file to find out how many records it holds.
+    :return: The number of records in the event data file, not including the header line.
+    """
+
+    lines = 0
+    for line in open(FILE_NAME):
+        lines += 1
+        
+    # Actual number of records is one less due to header line
+    return lines - 1
+
+    
+def calculate_section_of_event_data_file(number_records):
+    """
+    This function uses the instance settings and the number of records in the event data file to calculate the
+    section of the file which is owned by the current instance.
+    :param number_records: Is the number of entries in the event data file (ignoring the header line).
+    :return: The number of the first and last event data entries owned by the current instance. This is numbered from 0 and ignores the header line.
+    """
+
+    # Verify env.variables set
+    if INSTANCE_NUM is None:
+        sys.exit("ERROR: Environment variable 'INSTANCE_NUM' has not been set")
+    if MAX_INSTANCES is None:
+        sys.exit("ERROR: Environment variable 'MAX_INSTANCES' has not been set")
+
+    # Convert instance settings from strings
+    instance_num = int(INSTANCE_NUM)
+    max_instances = int(MAX_INSTANCES)
+    
+    # Sanity check the instance settings
+    if instance_num < 1 or instance_num > max_instances:
+        sys.stdout.write('ERROR: Invalid instance number: %d. Must be in the range 1...%d\n' % (instance_num, max_instances))
+        sys.exit(-1)
+    if max_instances < number_records:
+        sys.exit("ERROR: Event data file too small. There must be at least one worker instance per record in the file") 
+
+    # Calculate range of file owned by this instance
+    records_per_instance = number_records / max_instances
+    first_record = int(records_per_instance * (instance_num-1))
+    last_record = int(records_per_instance * (instance_num)) -1
+
+    sys.stdout.write('Instance %d/%d: Event range: %d...%d inclusive from %d records\n' % (instance_num, max_instances, first_record, last_record, number_records))
+
+    return (first_record, last_record)
+    
+
+def read_event_data(first_record, last_record):
+    """
+    Read in the section of the event data file which belongs to the current instance.
+    :param first_record: The first record from the CSV event data file to use. Numbered from 0 after the header line.
+    :param last_record: The final record from the CSV event data file that belongs to the current instance
+    """
+
+    with open(FILE_NAME, 'r') as infile:
+        reader = csv.DictReader(infile)
+        line_number = 0
+        for line in reader:
+            if line_number >= first_record and line_number <= last_record:
+                cases.append(line)
+            line_number += 1
+
+
 def publish_test_data():
+    """
+    Send all Case/UAC data from the event data file to the RH service.
+    """
+
     parameters = pika.URLParameters(RABBITMQ_URL)
     connection = pika.BlockingConnection(parameters)
     channel = connection.channel()
@@ -55,49 +123,6 @@ def publish_test_data():
                                   body=case_event)
 
     connection.close()
-
-
-def get_num_event_data_records():
-    lines = 0
-    for line in open(FILE_NAME):
-        lines += 1
-        
-    # Actual number of records is one less due to header line
-    return lines - 1
-
-    
-def calculate_section_of_event_data_file(number_records):
-    # Verify env.variables set
-    if INSTANCE_NUM is None:
-        sys.exit("ERROR: Environment variable 'INSTANCE_NUM' has not been set")
-    if MAX_INSTANCES is None:
-        sys.exit("ERROR: Environment variable 'MAX_INSTANCES' has not been set")
-
-    # Convert from strings
-    instance_num = int(INSTANCE_NUM)
-    max_instances = int(MAX_INSTANCES)
-    
-    # Sanity check the instance settings
-    # PMB TODO
-
-    # Calculate range of file owned by this instance
-    records_per_instance = number_records / max_instances
-    first_record = int(records_per_instance * (instance_num-1))
-    last_record = int(records_per_instance * (instance_num)) -1
-
-    sys.stdout.write('Instance %d/%d: Event range: %d...%d inclusive from %d records\n' % (instance_num, max_instances, first_record, last_record, number_records))
-
-    return (first_record, last_record)
-    
-
-def read_event_data(first_record, last_record):
-    with open(FILE_NAME, 'r') as infile:
-        reader = csv.DictReader(infile)
-        line_number = 0
-        for line in reader:
-            if line_number >= first_record and line_number <= last_record:
-                cases.append(line)
-            line_number += 1
 
 
 def uac_event_builder(line, case_id, collection_exercise_id):

--- a/locust_tasks/setup.py
+++ b/locust_tasks/setup.py
@@ -6,7 +6,6 @@ import sys
 import logging
 
 from uuid import uuid4
-from random import randrange
 
 from . import FILE_NAME, RABBITMQ_URL, EXCHANGE, UAC_ROUTING_KEY, CASE_ROUTING_KEY, DATA_PUBLISH, INSTANCE_NUM, MAX_INSTANCES
 
@@ -26,7 +25,6 @@ def get_next_case():
     global next_case_index
 
     next_case = cases[next_case_index]
-#    sys.stdout.write('NEXT: %d %s\n' % (next_case_index, next_case['uac']))
         
     next_case_index += 1
     if next_case_index >= len(cases):
@@ -50,7 +48,6 @@ def setup():
     num_event_rows = get_num_event_data_records()
     (first_record, last_record) = calculate_section_of_event_data_file(num_event_rows)            
     read_event_data(first_record, last_record)
-    next_case_index = 0
 
 
 def get_num_event_data_records():
@@ -60,7 +57,7 @@ def get_num_event_data_records():
     """
 
     lines = 0
-    for line in open(FILE_NAME):
+    for _ in open(FILE_NAME):
         lines += 1
         
     # Actual number of records is one less due to header line
@@ -99,7 +96,7 @@ def calculate_section_of_event_data_file(number_records):
 
     logger.info('Instance %d/%d: Event range: %d...%d inclusive from %d records\n' % (instance_num, max_instances, first_record, last_record, number_records))
 
-    return (first_record, last_record)
+    return first_record, last_record
     
 
 def read_event_data(first_record, last_record):


### PR DESCRIPTION
This PR is for:  

- Locust worker supports instance number and reads it own part of the event data file.
- Worker sequentially uses UAC's from event data file.
- Updated Readme, to describe use of new environment variables.

Also:

- Fixed deployment manifest so that master and workers can be deployed to GCP
- Fixed expected page titles to match latest.
- Extend list of know pages to match actual 502 errors from Python.